### PR TITLE
add logging components via "--with-logging"

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -98,9 +98,12 @@ install_vvp() {
     # try installation once (aborts and displays license)
     helm_install_vvp
 
-    read -r -p "Do you want to pass 'acceptCommunityEditionLicense=true'? (Y/n) " yn
+    read -r -p "Do you want to pass 'acceptCommunityEditionLicense=true'? (y/N) " yn
 
     case "$yn" in
+      "y")
+        helm_install_vvp --set acceptCommunityEditionLicense=true
+        ;;
       "Y")
         helm_install_vvp --set acceptCommunityEditionLicense=true
         ;;

--- a/setup.sh
+++ b/setup.sh
@@ -168,6 +168,10 @@ main() {
 
   echo "> Installing Ververica Platform..."
   install_vvp "$edition" "$install_metrics" || :
+
+  echo "> Waiting for all Deployments and Pods to become ready..."
+  kubectl --namespace vvp wait --timeout=5m --for=condition=available deployments --all
+  kubectl --namespace vvp wait --timeout=5m --for=condition=ready pods --all
 }
 
 main "$@"

--- a/teardown.sh
+++ b/teardown.sh
@@ -67,12 +67,15 @@ main() {
   echo -n "> Detecting Helm version... "
   HELM_VERSION="$(detect_helm_version)"
   echo "detected Helm ${HELM_VERSION}."
- 
+
   echo "> Uninstalling Helm applications..."
   helm_uninstall minio
   helm_uninstall vvp
   helm_uninstall prometheus
   helm_uninstall grafana
+  helm_uninstall elasticsearch
+  helm_uninstall fluentd
+  helm_uninstall kibana
  
   echo "> Deleting Kubernetes namespaces..."
   delete_namespaces

--- a/teardown.sh
+++ b/teardown.sh
@@ -51,9 +51,11 @@ main() {
   echo
   echo "The currently configured Kubernetes context is: ${kube_context}"
   echo
-  read -r -p "Are you sure you want to continue? (Y/n) " yn
+  read -r -p "Are you sure you want to continue? (y/N) " yn
 
   case $yn in
+    "y")
+      ;;
     "Y")
       ;;
     *)

--- a/values-elasticsearch.yaml
+++ b/values-elasticsearch.yaml
@@ -1,0 +1,22 @@
+replicas: 1
+minimumMasterNodes: 1
+
+resources:
+  requests:
+    cpu: "100m"
+    memory: "2Gi"
+  limits:
+    cpu: "1000m"
+    memory: "2Gi"
+
+# Hard means that by default pods will only be scheduled if there are enough nodes for them
+# and that they will never end up on the same node. Setting this to soft will do this "best effort"
+antiAffinity: "soft"
+
+# This is the max unavailable setting for the pod disruption budget
+# The default value of 1 will make sure that kubernetes won't allow more than 1
+# of your pods to be unavailable during maintenance
+maxUnavailable: 0
+
+# all primary shards are assigned, replicas unassigned (this is expected with 1 node only!)
+clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"

--- a/values-fluentd.yaml
+++ b/values-fluentd.yaml
@@ -1,0 +1,3 @@
+elasticsearch:
+  hosts:
+    - "elasticsearch-master.vvp.svc:9200"

--- a/values-kibana.yaml
+++ b/values-kibana.yaml
@@ -1,0 +1,48 @@
+fullnameOverride: "kibana"
+
+elasticsearchHosts: "http://elasticsearch-master:9200"
+
+replicas: 1
+
+resources:
+  requests:
+    cpu: "100m"
+    memory: "500Mi"
+  limits:
+    cpu: "1000m"
+    memory: "1Gi"
+
+# Allows you to add any config files in /usr/share/kibana/config/
+# such as kibana.yml
+kibanaConfig:
+  kibana.yml: |
+    logging.quiet: true
+    telemetry.enabled: false
+    telemetry.optIn: false
+
+# Hard means that by default pods will only be scheduled if there are enough nodes for them
+# and that they will never end up on the same node. Setting this to soft will do this "best effort"
+antiAffinity: "soft"
+
+# This is the max unavailable setting for the pod disruption budget
+# The default value of 1 will make sure that kubernetes won't allow more than 1
+# of your pods to be unavailable during maintenance
+maxUnavailable: 0
+
+lifecycle:
+  postStart:
+    exec:
+      command:
+        - bash
+        - -c
+        - |
+          #!/bin/bash
+          # Import a dashboard
+          KB_URL=http://localhost:5601
+          while [[ "$(curl -s -o /dev/null -w '%{http_code}\n' -L $KB_URL)" != "200" ]]; do sleep 1; done
+          curl -s -X POST -H 'Content-Type: application/json' -H 'kbn-xsrf: true' \
+              --data '{"attributes":{"title":"logstash-*","timeFieldName":"@timestamp"}}' \
+              "$KB_URL/api/saved_objects/index-pattern/logstash-*"
+          curl -s -X POST -H 'Content-Type: application/json' -H 'kbn-xsrf: true' \
+              --data '{"changes":{"defaultIndex":"logstash-*","doc_table:highlight":false}}' \
+              "$KB_URL/api/kibana/settings"

--- a/values-vvp-add-logging.yaml
+++ b/values-vvp-add-logging.yaml
@@ -1,0 +1,5 @@
+vvp:
+  ui:
+    linkTemplates:
+      jobLogs: "http://localhost:5601/app/kibana#/discover?_g=()&_a=(columns:!(level,host,message),index:'logstash-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'kubernetes.labels.jobId:<%= jobId %>')),sort:!('@timestamp',desc))&"
+      deploymentLogs: "http://localhost:5601/app/kibana#/discover?_g=()&_a=(columns:!(level,host,message,jobId),index:'logstash-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'kubernetes.labels.deploymentId:<%= deploymentId %>')),sort:!('@timestamp',desc))&"


### PR DESCRIPTION
# Whole PR

This PR contains the following improvements:
- remove code duplication during helm installations
- fix asking for user input in bash scripts
- wait for all deployments and pods to become available before finishing
- add logging components

# Logging

The implemented setup is based on:
- fluentd
- elasticsearch
- kibana

Use the following port-forward to get access via http://localhost:5601

```
kubectl --namespace vvp port-forward services/kibana 5601:5601
```

# Tests

I manually verified these commits with helm 2 and 3 and also verified that the deployment can still be scaled up to 2 (as before).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ververica/ververica-platform-playground/24)
<!-- Reviewable:end -->
