### PR TITLE
kibana: increase resource limits again

### DIFF
--- a/values-kibana.yaml
+++ b/values-kibana.yaml
@@ -7,10 +7,10 @@ replicas: 1
 resources:
   requests:
     cpu: "100m"
-    memory: "256Mi"
+    memory: "500Mi"
   limits:
     cpu: "1000m"
-    memory: "256Mi"
+    memory: "1Gi"
 
 # Allows you to add any config files in /usr/share/kibana/config/
 # such as kibana.yml


### PR DESCRIPTION
I had to increase the memory requests and limits again because with the current
resource limits, I cannot get Kibana deployed successfully on Azure.
The following error occurs:

```
  Warning  FailedPostStartHook  15m (x3 over 17m)  kubelet, aks-nodepool1-38276290-vmss0000ap  Exec lifecycle hook ([bash -c #!/bin/bash
KB_URL=http://localhost:5601
while [[ "$(curl -s -o /dev/null -w '%{http_code}\n' -L $KB_URL)" != "200" ]]; do sleep 1; done
curl -s -X POST -H 'Content-Type: application/json' -H 'kbn-xsrf: true' \
    --data '{"attributes":{"title":"logstash-*","timeFieldName":"@timestamp"}}' \
    "$KB_URL/api/saved_objects/index-pattern/logstash-*"
curl -s -X POST -H 'Content-Type: application/json' -H 'kbn-xsrf: true' \
    --data '{"changes":{"defaultIndex":"logstash-*","doc_table:highlight":false}}' \
    "$KB_URL/api/kibana/settings"
]) for Container "kibana" in Pod "kibana-ff9bd78f8-5gf57_vvp(1311bd61-1b83-484e-ba5d-c9e683ac8554)" failed - error: command 'bash -c #!/bin/bash
KB_URL=http://localhost:5601
while [[ "$(curl -s -o /dev/null -w '%{http_code}\n' -L $KB_URL)" != "200" ]]; do sleep 1; done
curl -s -X POST -H 'Content-Type: application/json' -H 'kbn-xsrf: true' \
    --data '{"attributes":{"title":"logstash-*","timeFieldName":"@timestamp"}}' \
    "$KB_URL/api/saved_objects/index-pattern/logstash-*"
curl -s -X POST -H 'Content-Type: application/json' -H 'kbn-xsrf: true' \
    --data '{"changes":{"defaultIndex":"logstash-*","doc_table:highlight":false}}' \
    "$KB_URL/api/kibana/settings"
' exited with 137: , message: ""
```

(Elasticsearch was up in both tests and Kibana immediately came up with the proposed settings but went into a `CrashLoopBackOff` with the current ones)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ververica/ververica-platform-playground/30)
<!-- Reviewable:end -->
