### PR TITLE
Update fluentd helm chart source

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -66,7 +66,7 @@ install_elasticsearch() {
 
 install_fluentd() {
   helm_install fluentd fluentd-elasticsearch vvp \
-    --repo https://kiwigrid.github.io \
+    --repo https://kokuwaio.github.io/helm-charts \
     --values values-fluentd.yaml
 }
 


### PR DESCRIPTION
According to https://github.com/kiwigrid/helm-charts/tree/master/charts/fluentd-elasticsearch, that chart has been deprecated.
The new chart is at https://github.com/kokuwaio/helm-charts/tree/main/charts/fluentd-elasticsearch.