### PR TITLE
[hotfix] Pin chart version to latest 2.4 release

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -6,6 +6,7 @@ set -o pipefail
 
 HELM=${HELM:-helm}
 VVP_CHART=${VVP_CHART:-}
+VVP_CHART_VERSION=${VVP_CHART_VERSION:-5.0.3}
 
 VVP_NAMESPACE=${VVP_NAMESPACE:-vvp}
 JOBS_NAMESPACE=${JOBS_NAMESPACE:-"vvp-jobs"}
@@ -85,6 +86,7 @@ install_kibana() {
 helm_install_vvp() {
   if [ -n "$VVP_CHART" ];  then
     helm_install vvp "$VVP_CHART" "$VVP_NAMESPACE" \
+      --version "$VVP_CHART_VERSION" \
       --values values-vvp.yaml \
       --set rbac.additionalNamespaces="{$JOBS_NAMESPACE}" \
       --set vvp.blobStorage.s3.endpoint="http://minio.$VVP_NAMESPACE.svc:9000" \
@@ -92,6 +94,7 @@ helm_install_vvp() {
   else
     helm_install vvp ververica-platform "$VVP_NAMESPACE" \
       --repo https://charts.ververica.com \
+      --version "$VVP_CHART_VERSION" \
       --values values-vvp.yaml \
       --set rbac.additionalNamespaces="{$JOBS_NAMESPACE}" \
       --set vvp.blobStorage.s3.endpoint="http://minio.$VVP_NAMESPACE.svc:9000" \


### PR DESCRIPTION
Not sure if this is intended, but the release-2.x branches all install the latest version since the chart version is unpinned, which is a bit confusing imo. Pinning to a specific chart version fixes this, but introduces one more place to update. 🤷🏼 lmk   