### PR TITLE
Master

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -67,19 +67,22 @@ install_grafana() {
 install_elasticsearch() {
   helm_install elasticsearch elasticsearch "$VVP_NAMESPACE" \
     --repo https://helm.elastic.co \
-    --values values-elasticsearch.yaml
+    --values values-elasticsearch.yaml \
+    --version 7.9.2
 }
 
 install_fluentd() {
   helm_install fluentd fluentd-elasticsearch "$VVP_NAMESPACE" \
     --repo https://kokuwaio.github.io/helm-charts \
-    --values values-fluentd.yaml
+    --values values-fluentd.yaml \
+    --version 13.2.0
 }
 
 install_kibana() {
   helm_install kibana kibana "$VVP_NAMESPACE" \
     --repo https://helm.elastic.co \
-    --values values-kibana.yaml
+    --values values-kibana.yaml \
+    --version 7.9.2
 }
 
 helm_install_vvp() {


### PR DESCRIPTION
Elasticsearch has made major changes in version 8.x, which is automatically pulled by Helm we run inside the setup.sh script. These major changes eventually lead to failing deployment of ES, Kibana and Fluentd connector Pods. Our Helm values for logging components should be adjusted to make everything to work again. 

Quick fix is proposed in this PR to still use that suitable for our version which is was probably the latest version back then when this script was developed initially.