### PR TITLE
Update minio repo

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -44,7 +44,7 @@ helm_install() {
 
 install_minio() {
   helm_install minio minio "$VVP_NAMESPACE" \
-    --repo https://helm.min.io \
+    --repo https://charts.helm.sh/stable \
     --values values-minio.yaml
 }
 


### PR DESCRIPTION
## Issue
The setup script was pointing an unavailable helm [repo](https://helm.min.io) of minio.

## Fix
Updated the repo to use the stable helm charts [directory](https://charts.helm.sh/stable).