### PR TITLE
Update Flink version to 1.18.1

### DIFF
--- a/vvp-resources/deployment.yaml
+++ b/vvp-resources/deployment.yaml
@@ -13,5 +13,5 @@ spec:
         kind: JAR
         flinkVersion: '1.18'
         jarUri: >-
-          https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.18.1/flink-examples-streaming_2.12-1.18.1-TopSpeedWindowing.jar
+          https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming/1.18.1/flink-examples-streaming-1.18.1-WindowJoin.jar
 

--- a/vvp-resources/deployment.yaml
+++ b/vvp-resources/deployment.yaml
@@ -13,5 +13,5 @@ spec:
         kind: JAR
         flinkVersion: '1.18'
         jarUri: >-
-          https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.18.0/flink-examples-streaming_2.12-1.18.0-TopSpeedWindowing.jar
+          https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.18.1/flink-examples-streaming_2.12-1.18.1-TopSpeedWindowing.jar
 


### PR DESCRIPTION
Updating the Flink version to point to 1.18.1 in the scope of VVP 2.12.1 that supports Flink 1.18.1.