### PR TITLE
Update HA Configuration

### DIFF
--- a/values-vvp.yaml
+++ b/values-vvp.yaml
@@ -26,7 +26,7 @@ vvp:
           flinkConfiguration:
             state.backend: filesystem
             taskmanager.memory.managed.fraction: 0.0 # no managed memory needed for filesystem statebackend
-            high-availability: vvp-kubernetes
+            high-availability: kubernetes
             metrics.reporter.prom.class: org.apache.flink.metrics.prometheus.PrometheusReporter
             execution.checkpointing.interval: 10s
             execution.checkpointing.externalized-checkpoint-retention: RETAIN_ON_CANCELLATION


### PR DESCRIPTION
## Issue
The high availability option `vvp-kubernetes` has been deprecated and blocks the deployment submission.

## Fix
Updation the high availability configuration to `kubernetes`.